### PR TITLE
XMLFactory using class cannonical names

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>cat.altimiras</groupId>
   <artifactId>sherlockXML</artifactId>
-  <version>2.0.0-beta</version>
+  <version>2.0.0</version>
   <build>
     <plugins>
       <plugin>

--- a/src/main/java/cat/altimiras/xml/XMLFactory.java
+++ b/src/main/java/cat/altimiras/xml/XMLFactory.java
@@ -19,9 +19,9 @@ public class XMLFactory {
 		}
 
 		for (Class c : classes) {
-			if (classesIntrospector.get(c.getSimpleName()) == null) {
+			if (classesIntrospector.get(c.getCanonicalName()) == null) {
 				ClassIntrospector classIntrospector = new ClassIntrospector(c);
-				classesIntrospector.put(c.getSimpleName(), classIntrospector);
+				classesIntrospector.put(c.getCanonicalName(), classIntrospector);
 			}
 		}
 	}
@@ -41,9 +41,9 @@ public class XMLFactory {
 			throw new IllegalArgumentException("Class can not be null");
 		}
 
-		ClassIntrospector classIntrospector = classesIntrospector.get(c.getSimpleName());
+		ClassIntrospector classIntrospector = classesIntrospector.get(c.getCanonicalName());
 		if (classIntrospector == null) {
-			throw new IllegalArgumentException("XMLFactory has not been properly initialzed. Class:" + c.getSimpleName() + ". Check init method");
+			throw new IllegalArgumentException("XMLFactory has not been properly initialzed. Class:" + c.getCanonicalName() + ". Check init method");
 		}
 		return new WoodStoxObjParserImpl(c, classIntrospector);
 	}

--- a/src/main/java/cat/altimiras/xml/obj/WoodStoxObjParserImpl.java
+++ b/src/main/java/cat/altimiras/xml/obj/WoodStoxObjParserImpl.java
@@ -400,9 +400,11 @@ public class WoodStoxObjParserImpl<T extends XMLElement> implements XMLParser<T>
 
 		while (!contexts.isEmpty()) {
 			Context current = contexts.pollFirst();
-			Field field = classIntrospector.getField(current.object.getClass(), nested.tag);
-			setToObj(current.object, field, nested.object);
-			nested = current;
+			if(current != null && nested != null){
+				Field field = classIntrospector.getField(current.object.getClass(), nested.tag);
+				setToObj(current.object, field, nested.object);
+				nested = current;
+			}
 		}
 
 		obj.markAsIncomplete();


### PR DESCRIPTION
When using the parser for XML schemes where the request has the same root element as the response, the parser is not able to parse it correctly with the simple name of the class. Using the cannonical name is a simple workaround but useful in this case (although using larger strings). Is there any other drawback in using the cannonical name ?